### PR TITLE
remove the timestamps shift trick to have correct data download.

### DIFF
--- a/src/main/java/gsn/http/datarequest/DownloadData.java
+++ b/src/main/java/gsn/http/datarequest/DownloadData.java
@@ -277,7 +277,7 @@ public class DownloadData extends AbstractDataRequest {
             respond.println();
         }
         if (wantTimed) {
-            respond.print(qbuilder.getSdf() == null ? timestampInUTC(se.getTimeStamp()) : qbuilder.getSdf().format(new Date(se.getTimeStamp())));
+            respond.print(qbuilder.getSdf() == null ? se.getTimeStamp() : qbuilder.getSdf().format(new Date(se.getTimeStamp())));
         }
         for (int i = 0; i < se.getData().length; i++) {
             respond.print(cvsDelimiter);
@@ -299,17 +299,11 @@ public class DownloadData extends AbstractDataRequest {
         }
         respond.println("\t\t<tuple>");
         if (wantTimed)
-            respond.println("\t\t\t<field>" + (qbuilder.getSdf() == null ? timestampInUTC(se.getTimeStamp()) : qbuilder.getSdf().format(new Date(se.getTimeStamp()))) + "</field>");
+            respond.println("\t\t\t<field>" + (qbuilder.getSdf() == null ? se.getTimeStamp() : qbuilder.getSdf().format(new Date(se.getTimeStamp()))) + "</field>");
         for (int i = 0; i < se.getData().length; i++) {
             respond.println("\t\t\t<field>" + se.getData()[i] + "</field>");
         }
         respond.println("\t\t</tuple>");
-    }
-
-    private long timestampInUTC(long timestamp) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(timestamp);
-        return cal.getTimeInMillis() + cal.getTimeZone().getOffset(cal.getTimeInMillis());
     }
 
     public AllowedOutputType getOt() {

--- a/src/main/webapp/js/d3plots/timeseries.js
+++ b/src/main/webapp/js/d3plots/timeseries.js
@@ -68,7 +68,7 @@ function drawChartTimeseries(data){
 	var xAxis = d3.svg.axis()
 		.scale(x)
 		.orient("bottom")
-		.tickFormat(d3.time.format.utc("%d/%m/%Y %H:%M:%S"));
+		.tickFormat(d3.time.format("%d/%m/%Y %H:%M:%S"));
 
 	var yAxis = d3.svg.axis()
 		.scale(y)
@@ -180,11 +180,11 @@ function drawChartTimeseries(data){
             var x1 = selectedTimeRangeHistory[currentTimeRangeShown].min;
             var x2 = selectedTimeRangeHistory[currentTimeRangeShown].max;
             selectedTimeRangeHistory[currentTimeRangeShown + 1] = null;
-            var x1Month = x1.getUTCMonth() + 1;
-            var x2Month = x2.getUTCMonth() + 1;
+            var x1Month = x1.getMonth() + 1;
+            var x2Month = x2.getMonth() + 1;
 
-            $("#datepicker_from").val(x1.getUTCDate() + "/" + x1Month +  "/" + x1.getUTCFullYear() + " " + x1.getUTCHours() + ":" + x1.getUTCMinutes() + ":" + x1.getUTCSeconds());
-            $("#datepicker_to").val(x2.getUTCDate() + "/" + x2Month +  "/" + x2.getUTCFullYear() + " " + x2.getUTCHours() + ":" + x2.getUTCMinutes() + ":" + x2.getUTCSeconds());
+            $("#datepicker_from").val(x1.getDate() + "/" + x1Month +  "/" + x1.getFullYear() + " " + x1.getHours() + ":" + x1.getMinutes() + ":" + x1.getSeconds());
+            $("#datepicker_to").val(x2.getDate() + "/" + x2Month +  "/" + x2.getFullYear() + " " + x2.getHours() + ":" + x2.getMinutes() + ":" + x2.getSeconds());
 
             var newData = [];
             for (var i=0;i<allData.length;i++){
@@ -206,11 +206,11 @@ function drawChartTimeseries(data){
 		var x2=e[1][0];
 
         //update datetime fields
-        var x1Month = x1.getUTCMonth() + 1;
-        var x2Month = x2.getUTCMonth() + 1;
+        var x1Month = x1.getMonth() + 1;
+        var x2Month = x2.getMonth() + 1;
 
-        $("#datepicker_from").val(x1.getUTCDate() + "/" + x1Month +  "/" + x1.getUTCFullYear() + " " + x1.getUTCHours() + ":" + x1.getUTCMinutes() + ":" + x1.getUTCSeconds());
-        $("#datepicker_to").val(x2.getUTCDate() + "/" + x2Month +  "/" + x2.getUTCFullYear() + " " + x2.getUTCHours() + ":" + x2.getUTCMinutes() + ":" + x2.getUTCSeconds());
+        $("#datepicker_from").val(x1.getDate() + "/" + x1Month +  "/" + x1.getFullYear() + " " + x1.getHours() + ":" + x1.getMinutes() + ":" + x1.getSeconds());
+        $("#datepicker_to").val(x2.getDate() + "/" + x2Month +  "/" + x2.getFullYear() + " " + x2.getHours() + ":" + x2.getMinutes() + ":" + x2.getSeconds());
 
 
         if (typeof $("#plotBack") != 'undefined')  $("#plotBack").remove();


### PR DESCRIPTION
(timestamps are meant to be timezone independent). 
The current trick is to shift the timestamps according to the timezone of the server, so that the plotting library can just use "UTC" time. But when downloading data, this makes the timestamps wrong. 
Some other problems appear when the server and the client are not in the same timezone and it make the plot and front-page values not consistent. 

So the chosen solution is to always use the clients timezone for display. But I haven't checked if other parts of GSN (or external dependencies) where using /multidata servlet. They may be broken if they assume the shift in the timestamps.