### PR TITLE
Fixes merge conflict in RequestHandler.java

### DIFF
--- a/src/main/java/gsn/http/restapi/RequestHandler.java
+++ b/src/main/java/gsn/http/restapi/RequestHandler.java
@@ -890,8 +890,6 @@ public class RequestHandler {
     
     
     //properties file
-    private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "conf/RestApiConstants.properties";
-    private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "src/main/resources/RestApiConstants.properties";
     private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "RestApiConstants.properties";
     private static Properties stringConstantsProperties = new Properties();
     private FileInputStream stringConstantsPropertiesFileInputStream= null;


### PR DESCRIPTION
When I performed an `ant build` I was seeing the following errors:

```
[javac] /home/ubuntu/gsn/src/main/java/gsn/http/restapi/RequestHandler.java:894: error: variable STRING_CONSTANTS_PROPERTIES_FILENAME is already defined in class RequestHandler
[javac]     private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "src/main/resources/RestApiConstants.properties";
[javac]                                 ^
[javac] /home/ubuntu/gsn/src/main/java/gsn/http/restapi/RequestHandler.java:895: error: variable STRING_CONSTANTS_PROPERTIES_FILENAME is already defined in class RequestHandler
[javac]     private static final String STRING_CONSTANTS_PROPERTIES_FILENAME = "RestApiConstants.properties";
[javac]                                 ^

```

This was because the `STRING_CONSTANTS_PROPERTIES_FILENAME` was defined multiple times. Looking at some of the recent commits, it looked like this was due to changes to this variable which led to a merge conflict. It seems like the desired value should be `"RestApiConstants.properties"`, so I removed the duplicate copies. Please let me know if this variable should have a different value. 

Thanks! 
